### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,9 @@
 
 name: Run linters, formatters, and tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wushenrong/legacy-puyo-tools/security/code-scanning/2](https://github.com/wushenrong/legacy-puyo-tools/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will apply to all jobs in the workflow unless overridden by a job-specific `permissions` block. Since the workflow only needs to read repository contents (e.g., to run tests and linters), we will set `contents: read` as the minimal required permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
