### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -4,6 +4,9 @@
 
 name: gitleaks
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/wushenrong/legacy-puyo-tools/security/code-scanning/1](https://github.com/wushenrong/legacy-puyo-tools/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow. Since the `gitleaks` action primarily reads repository contents to scan for secrets, we will set `contents: read` as the permission. This ensures that the workflow has only the necessary permissions and no unintended write access.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
